### PR TITLE
Use logical_path and full filename for matching removed keys

### DIFF
--- a/spec/rails_asset_digest_spec.coffee
+++ b/spec/rails_asset_digest_spec.coffee
@@ -32,6 +32,7 @@ describe "rails_asset_digest", ->
       "assets": {
         "entry-we-didnt-touch.js" : "entry-we-didnt-touch-536a9e5d711e0593e43360ad330ccc31.js"
         "thing-that-existed.js" : "thing-that-existed-536a9e5ddkfjc9v9e9r939494949491.js"
+        "style/style-should-stay.css" : "style-should-stay-OLDSHA.css"
       }
       "files": {
         "thing-that-existed-536a9e5ddkfjc9v9e9r939494949491.js" : {
@@ -45,6 +46,12 @@ describe "rails_asset_digest", ->
           "digest": "536a9e5d711e0593e43360ad330ccc31",
           "size": 32,
           "logical_path": "entry-we-didnt-touch.js"
+        }
+        "style/style-should-stay-OLDSHA.css" : {
+          "mtime": "2014-02-04T18:14:52.000Z"
+          "digest": "OLDSHA"
+          "size": 32
+          "logical_path": "style/style-should-stay.css"
         }
       }
     }
@@ -98,6 +105,7 @@ describe "rails_asset_digest", ->
         "othersubdirectory/generated-tree.js" : "othersubdirectory/generated-tree-OLDSHA.js"
         "subdirectory/with/alibrary.js" : "subdirectory/with/alibrary-313b3b4b01cec6e4e82bdeeb258503c5.js"
         "style.css" : "style-OLDSHA.css"
+        "style/style-should-stay.css" : "style-should-stay-OLDSHA.css"
       }
       "files": {
         "rootfile-OLDSHA.js" : {
@@ -129,6 +137,12 @@ describe "rails_asset_digest", ->
           "digest": "OLDSHA"
           "size": 32
           "logical_path": "style.css"
+        }
+        "style/style-should-stay-OLDSHA.css" : {
+          "mtime": "2014-02-04T18:14:52.000Z"
+          "digest": "OLDSHA"
+          "size": 32
+          "logical_path": "style/style-should-stay.css"
         }
       }
     }

--- a/tasks/rails_asset_digest.coffee
+++ b/tasks/rails_asset_digest.coffee
@@ -21,9 +21,9 @@ module.exports = (grunt) ->
       path += "/"
     path
 
-  removeKeysThatStartWith = (filepath, ext, obj) ->
+  removeOldKeys = (filepath, obj) ->
     keys = _.keys(obj)
-    actualKeysToRemove = _(keys).filter (key) -> _s.startsWith(key, filepath)
+    actualKeysToRemove = _(keys).filter (key) -> obj[key].logical_path == filepath
     _(actualKeysToRemove).each (key) -> delete obj[key]
     obj
 
@@ -66,7 +66,6 @@ module.exports = (grunt) ->
       digest = algorithmHash.update(content).digest("hex")
       stats = fs.statSync(src)
       undigestedFilename = "#{path.dirname(dest)}/#{path.basename(dest, extension)}#{extension}"
-      undigestedFilenameWithoutPrefix = "#{path.dirname(dest)}/#{path.basename(dest, extension)}"
       digestedFilename = "#{path.dirname(dest)}/#{path.basename(dest, extension)}-#{digest}#{extension}"
 
       addedManifestFileEntries[stripAssetPath digestedFilename] = {
@@ -79,10 +78,10 @@ module.exports = (grunt) ->
       addedManifestAssetEntries[stripAssetPath undigestedFilename] = stripAssetPath digestedFilename
 
       if existingManifestFilesData
-        existingManifestFilesData = removeKeysThatStartWith(stripAssetPath(undigestedFilenameWithoutPrefix), extension, existingManifestFilesData)
+        existingManifestFilesData = removeOldKeys(stripAssetPath(undigestedFilename), existingManifestFilesData)
 
       if existingManifestAssetsData
-        existingManifestAssetsData = removeKeysThatStartWith(stripAssetPath(undigestedFilenameWithoutPrefix), extension, existingManifestAssetsData)
+        existingManifestAssetsData = removeOldKeys(stripAssetPath(undigestedFilename), existingManifestAssetsData)
 
       grunt.file.write digestedFilename, content
       grunt.log.writeln "File #{digestedFilename} created."


### PR DESCRIPTION
Fixes an issue where filepaths that partially matched assets lineman handled were being stripped from rails supplied manifests.

@davemo
